### PR TITLE
openvpn process shutdown on session destroy

### DIFF
--- a/openvpn/cmd_wrapper.go
+++ b/openvpn/cmd_wrapper.go
@@ -57,6 +57,12 @@ func (cw *CmdWrapper) Start(arguments []string) (err error) {
 	// Create the command
 	cmd := cw.command(arguments...)
 
+	// reset stale variables
+	cw.CmdExitError = make(chan error, 1)
+	cw.cmdShutdownStarted = make(chan bool, 1)
+	cw.cmdShutdownWaiter = sync.WaitGroup{}
+	cw.closesOnce = sync.Once{}
+
 	if len(cmd.Args) == 0 {
 		return errors.New("nothing to execute for an empty command")
 	}

--- a/openvpn/cmd_wrapper.go
+++ b/openvpn/cmd_wrapper.go
@@ -39,6 +39,7 @@ func NewCmdWrapper(logPrefix string, commandFunc CommandFunc) *CmdWrapper {
 		CmdExitError:       make(chan error, 1), //channel should have capacity to hold single process exit error
 		cmdShutdownStarted: make(chan bool),
 		cmdShutdownWaiter:  sync.WaitGroup{},
+		closesOnce:         sync.Once{},
 	}
 }
 
@@ -56,12 +57,6 @@ type CmdWrapper struct {
 func (cw *CmdWrapper) Start(arguments []string) (err error) {
 	// Create the command
 	cmd := cw.command(arguments...)
-
-	// reset stale variables
-	cw.CmdExitError = make(chan error, 1)
-	cw.cmdShutdownStarted = make(chan bool, 1)
-	cw.cmdShutdownWaiter = sync.WaitGroup{}
-	cw.closesOnce = sync.Once{}
 
 	if len(cmd.Args) == 0 {
 		return errors.New("nothing to execute for an empty command")

--- a/openvpn/process.go
+++ b/openvpn/process.go
@@ -125,7 +125,6 @@ func (openvpn *OpenvpnProcess) Wait() error {
 			return exitError
 		}
 	}
-	return nil
 }
 
 // Stop stops the openvpn process

--- a/openvpn/process_factory.go
+++ b/openvpn/process_factory.go
@@ -26,10 +26,10 @@ import (
 )
 
 // CreateNewProcess creates new openvpn process with given config params
-func CreateNewProcess(openvpnBinary string, config *config.GenericConfig, middlewares ...management.Middleware) *OpenvpnProcess {
+func CreateNewProcess(openvpnBinary string, config *config.GenericConfig, lastSessionShutdown chan bool, middlewares ...management.Middleware) *OpenvpnProcess {
 	tunnelSetup := tunnel.NewTunnelSetup()
 	execCommand := func(arg ...string) *exec.Cmd {
 		return exec.Command(openvpnBinary, arg...)
 	}
-	return newProcess(tunnelSetup, config, execCommand, middlewares...)
+	return newProcess(tunnelSetup, config, execCommand, lastSessionShutdown, middlewares...)
 }


### PR DESCRIPTION
changes fixing service shutdown essential for NAT traversal.

Might need to remove some varbose logging probably. 