### PR TITLE
Expose tunnel interface name from openvpn process

### DIFF
--- a/openvpn/process.go
+++ b/openvpn/process.go
@@ -129,3 +129,8 @@ func (openvpn *OpenvpnProcess) Stop() {
 
 	openvpn.tunnelSetup.Stop()
 }
+
+// DeviceName returns tunnel device name
+func (openvpn *OpenvpnProcess) DeviceName() string {
+	return openvpn.tunnelSetup.DeviceName()
+}

--- a/openvpn/process_interface.go
+++ b/openvpn/process_interface.go
@@ -23,4 +23,5 @@ type Process interface {
 	Start() error
 	Wait() error
 	Stop()
+	DeviceName() string
 }

--- a/openvpn/tunnel/setup_default.go
+++ b/openvpn/tunnel/setup_default.go
@@ -33,3 +33,8 @@ func (ds *DefaultSetup) Setup(config *config.GenericConfig) error {
 func (ds *DefaultSetup) Stop() {
 
 }
+
+// DeviceName returns tunnel device name
+func (ds *DefaultSetup) DeviceName() string {
+	return "tun"
+}

--- a/openvpn/tunnel/setup_noop.go
+++ b/openvpn/tunnel/setup_noop.go
@@ -32,3 +32,8 @@ func (gts *NoopSetup) Setup(config *config.GenericConfig) error {
 func (gts *NoopSetup) Stop() {
 
 }
+
+// DeviceName returns tunnel device name
+func (gts *NoopSetup) DeviceName() string {
+	return ""
+}

--- a/openvpn/tunnel/setup_tun_interface.go
+++ b/openvpn/tunnel/setup_tun_interface.go
@@ -32,4 +32,5 @@ var ErrNoFreeTunDevice = errors.New("no free tun device found")
 type Setup interface {
 	Setup(config *config.GenericConfig) error
 	Stop()
+	DeviceName() string
 }

--- a/openvpn/tunnel/setup_tun_linux.go
+++ b/openvpn/tunnel/setup_tun_linux.go
@@ -83,6 +83,11 @@ func (service *LinuxTunDeviceManager) Stop() {
 	}
 }
 
+// DeviceName returns tunnel device name
+func (service *LinuxTunDeviceManager) DeviceName() string {
+	return service.device.Name
+}
+
 func (service *LinuxTunDeviceManager) createTunDevice(deviceName string) (err error) {
 	cmd := exec.Command("sudo", "ip", "tuntap", "add", "dev", deviceName, "mode", "tun")
 	if output, err := cmd.CombinedOutput(); err != nil {

--- a/openvpn3/callback_registry_test.go
+++ b/openvpn3/callback_registry_test.go
@@ -17,8 +17,9 @@
 
 package openvpn3
 
-import "testing"
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
In order to [limit bandwidth on the node side][1], it's needed to expose the tunnel interface name created by `go-openvpn`.

[1]: https://github.com/mysteriumnetwork/node/issues/1273