### PR TITLE
Allow customizing logger

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,14 +2,6 @@
 
 
 [[projects]]
-  digest = "1:50e893a85575fa48dc4982a279e50e2fd8b74e4f7c587860c1e25c77083b8125"
-  name = "github.com/cihub/seelog"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "d2c6e5aa9fbfdd1c624e140287063c7730654115"
-  version = "v2.6"
-
-[[projects]]
   digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
@@ -58,7 +50,6 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
-    "github.com/cihub/seelog",
     "github.com/magefile/mage/mage",
     "github.com/magefile/mage/mg",
     "github.com/magefile/mage/sh",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -27,10 +27,6 @@
 required = ["github.com/magefile/mage/mage"]
 
 [[constraint]]
-  name = "github.com/cihub/seelog"
-  version = "2.6.0"
-
-[[constraint]]
   name = "github.com/stretchr/testify"
   version = "1.2.2"
 

--- a/openvpn/cmd_wrapper.go
+++ b/openvpn/cmd_wrapper.go
@@ -20,12 +20,11 @@ package openvpn
 import (
 	"bufio"
 	"errors"
+	"io"
 	"os/exec"
 	"sync"
 
-	"io"
-
-	log "github.com/cihub/seelog"
+	"github.com/mysteriumnetwork/go-openvpn/openvpn/log"
 )
 
 // CommandFunc represents the func for running external commands
@@ -61,7 +60,7 @@ func (cw *CmdWrapper) Start(arguments []string) (err error) {
 		return errors.New("nothing to execute for an empty command")
 	}
 
-	log.Info(cw.logPrefix, "Starting cmd: ", cmd.Args[0], " with arguments: ", arguments)
+	log.Info(cw.logPrefix, "Starting cmd:", cmd.Args[0], "with arguments:", arguments)
 
 	// Attach logger for stdout and stderr
 	stdout, err := cmd.StdoutPipe()
@@ -72,8 +71,8 @@ func (cw *CmdWrapper) Start(arguments []string) (err error) {
 	if err != nil {
 		return err
 	}
-	go cw.outputToLog(stdout, "Stdout: ")
-	go cw.outputToLog(stderr, "Stderr: ")
+	go cw.outputToLog(stdout, "Stdout:")
+	go cw.outputToLog(stderr, "Stderr:")
 
 	// Try to start the cmd
 	err = cmd.Start()
@@ -109,10 +108,10 @@ func (cw *CmdWrapper) Stop() {
 func (cw *CmdWrapper) outputToLog(output io.ReadCloser, streamPrefix string) {
 	scanner := bufio.NewScanner(output)
 	for scanner.Scan() {
-		log.Trace(cw.logPrefix, streamPrefix, scanner.Text())
+		log.Debug(cw.logPrefix, streamPrefix, scanner.Text())
 	}
 	if err := scanner.Err(); err != nil {
-		log.Warn(cw.logPrefix, streamPrefix, "(failed to read: ", err, ")")
+		log.Warn(cw.logPrefix, streamPrefix, "failed to read:", err)
 	} else {
 		log.Info(cw.logPrefix, streamPrefix, "stream ended")
 	}
@@ -128,6 +127,6 @@ func (cw *CmdWrapper) waitForShutdown(cmd *exec.Cmd) {
 	//First - shutdown gracefully by sending SIGINT (the only two signals guaranteed to be present in all OS'es SIGINT and SIGKILL)
 	//TODO - add timer and send SIGKILL after timeout?
 	if err := cmd.Process.Signal(exitSignal); err != nil {
-		log.Error(cw.logPrefix, "Error killing cw = ", err)
+		log.Error(cw.logPrefix, "Error killing cw:", err)
 	}
 }

--- a/openvpn/log.go
+++ b/openvpn/log.go
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/go-openvpn" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package openvpn
+
+import "github.com/mysteriumnetwork/go-openvpn/openvpn/log"
+
+// UseLogger sets go-openvpn library logger.
+func UseLogger(l log.Logger) {
+	log.UseLogger(l)
+}
+
+// UseDefaultLogger resets logger to the default logger.
+func UseDefaultLogger() {
+	log.UseDefaultLogger()
+}

--- a/openvpn/log/log.go
+++ b/openvpn/log/log.go
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/go-openvpn" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package log
+
+// Logger interface to go-openvpn library logger.
+// Stdout implementation is used by default.
+type Logger interface {
+	Error(args ...interface{})
+	Warn(args ...interface{})
+	Info(args ...interface{})
+	Debug(args ...interface{})
+}
+
+var logger Logger = stdLogger{}
+
+// UseLogger sets go-openvpn library logger.
+func UseLogger(l Logger) {
+	logger = l
+}
+
+// UseDefaultLogger resets logger to the default logger.
+func UseDefaultLogger() {
+	logger = stdLogger{}
+}
+
+// Error prints an error.
+func Error(args ...interface{}) {
+	logger.Error(args...)
+}
+
+// Warn prints a warning.
+func Warn(args ...interface{}) {
+	logger.Warn(args...)
+}
+
+// Info prints information.
+func Info(args ...interface{}) {
+	logger.Info(args...)
+}
+
+// Debug prints debug message.
+func Debug(args ...interface{}) {
+	logger.Debug(args...)
+}

--- a/openvpn/log/stdlog.go
+++ b/openvpn/log/stdlog.go
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/go-openvpn" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package log
+
+import (
+	"log"
+)
+
+type stdLogger struct {
+}
+
+func (l stdLogger) Error(args ...interface{}) {
+	var msg []interface{}
+	msg = append(msg, "ERROR")
+	msg = append(msg, args...)
+	log.Println(msg...)
+}
+
+func (l stdLogger) Warn(args ...interface{}) {
+	var msg []interface{}
+	msg = append(msg, "WARN ")
+	msg = append(msg, args...)
+	log.Println(msg...)
+}
+
+func (l stdLogger) Info(args ...interface{}) {
+	var msg []interface{}
+	msg = append(msg, "INFO ")
+	msg = append(msg, args...)
+	log.Println(msg...)
+}
+
+func (l stdLogger) Debug(args ...interface{}) {
+	var msg []interface{}
+	msg = append(msg, "DEBUG")
+	msg = append(msg, args...)
+	log.Println(msg...)
+}

--- a/openvpn/middlewares/client/auth/middleware.go
+++ b/openvpn/middlewares/client/auth/middleware.go
@@ -20,8 +20,8 @@ package auth
 import (
 	"regexp"
 
-	log "github.com/cihub/seelog"
 	"github.com/mysteriumnetwork/go-openvpn/openvpn"
+	"github.com/mysteriumnetwork/go-openvpn/openvpn/log"
 	"github.com/mysteriumnetwork/go-openvpn/openvpn/management"
 )
 
@@ -48,7 +48,7 @@ func NewMiddleware(credentials CredentialsProvider) *middleware {
 
 func (m *middleware) Start(commandWriter management.CommandWriter) error {
 	m.commandWriter = commandWriter
-	log.Info("starting client user-pass provider middleware")
+	log.Info("Starting client user-pass provider middleware")
 	return nil
 }
 
@@ -67,7 +67,7 @@ func (m *middleware) ConsumeLine(line string) (consumed bool, err error) {
 		return false, err
 	}
 
-	log.Info("authenticating user ", username)
+	log.Info("Authenticating user", username)
 
 	_, err = m.commandWriter.SingleLineCommand("password 'Auth' %s", password)
 	if err != nil {

--- a/openvpn/middlewares/server/auth/middleware.go
+++ b/openvpn/middlewares/server/auth/middleware.go
@@ -20,7 +20,7 @@ package auth
 import (
 	"strings"
 
-	log "github.com/cihub/seelog"
+	"github.com/mysteriumnetwork/go-openvpn/openvpn/log"
 	"github.com/mysteriumnetwork/go-openvpn/openvpn/management"
 )
 
@@ -116,10 +116,10 @@ func (m *middleware) ConsumeLine(line string) (bool, error) {
 		}
 		m.startOfEvent(eventType, ID, undefined)
 	case address:
-		log.Info("Address for client: ", eventData)
+		log.Info("Address for client:", eventData)
 	default:
-		log.Error("Undefined user notification event: ", eventType, eventData)
-		log.Error("Original line was: ", line)
+		log.Error("Undefined user notification event:", eventType, eventData)
+		log.Error("Original line was:", line)
 	}
 	return true, nil
 }
@@ -150,12 +150,12 @@ func (m *middleware) handleClientEvent(event clientEvent) {
 		password := event.env["password"]
 		err := m.authenticateClient(event.clientID, event.clientKey, username, password)
 		if err != nil {
-			log.Error("Unable to authenticate client. Error: ", err)
+			log.Error("Unable to authenticate client:", err)
 		}
 	case established:
-		log.Info("Client with ID: ", event.clientID, " connection established successfully")
+		log.Info("Client with ID:", event.clientID, "connection established successfully")
 	case disconnect:
-		log.Info("Client with ID: ", event.clientID, " disconnected")
+		log.Info("Client with ID:", event.clientID, "disconnected")
 		// NOTE: do not cleanup session after disconnect event risen by transport itself
 		//  cleanup session only by user's intent
 	}
@@ -167,11 +167,11 @@ func (m *middleware) authenticateClient(clientID, clientKey int, username, passw
 		return denyClientAuthWithMessage(m.commandWriter, clientID, clientKey, "missing username or password")
 	}
 
-	log.Info("authenticating user: ", username, " clientID: ", clientID, " clientKey: ", clientKey)
+	log.Info("Authenticating user:", username, "clientID:", clientID, "clientKey:", clientKey)
 
 	authenticated, err := m.credentialsValidator(clientID, username, password)
 	if err != nil {
-		log.Error("Authentication error: ", err)
+		log.Error("Authentication error:", err)
 		return denyClientAuthWithMessage(m.commandWriter, clientID, clientKey, "internal error")
 	}
 

--- a/openvpn/process.go
+++ b/openvpn/process.go
@@ -28,8 +28,8 @@ import (
 	"github.com/mysteriumnetwork/go-openvpn/openvpn/tunnel"
 )
 
-const openvpnManagementLogPrefix = "[client-management] "
-const openvpnProcessLogPrefix = "[openvpn-process] "
+const openvpnManagementLogPrefix = "[openvpn-mgmt]"
+const openvpnProcessLogPrefix = "[openvpn-proc]"
 
 // OpenvpnProcess represents an openvpn process manager
 type OpenvpnProcess struct {

--- a/openvpn/tunnel/setup_tun_linux.go
+++ b/openvpn/tunnel/setup_tun_linux.go
@@ -24,10 +24,10 @@ import (
 	"strconv"
 	"strings"
 
-	log "github.com/cihub/seelog"
 	"github.com/pkg/errors"
 
 	"github.com/mysteriumnetwork/go-openvpn/openvpn/config"
+	"github.com/mysteriumnetwork/go-openvpn/openvpn/log"
 )
 
 // NewTunnelSetup returns a new tunnel setup for linux
@@ -91,12 +91,12 @@ func (service *LinuxTunDeviceManager) DeviceName() string {
 func (service *LinuxTunDeviceManager) createTunDevice(deviceName string) (err error) {
 	cmd := exec.Command("sudo", "ip", "tuntap", "add", "dev", deviceName, "mode", "tun")
 	if output, err := cmd.CombinedOutput(); err != nil {
-		log.Warn("Failed to add tun device: ", cmd.Args, " Returned exit error: ", err.Error(), " Cmd output: ", string(output))
+		log.Warn("Failed to add tun device:", cmd.Args, "Returned exit error:", err, "Cmd output:", string(output))
 		// we should not proceed without tun device
 		return err
 	}
 
-	log.Info(tunLogPrefix, deviceName+" device created")
+	log.Info(tunLogPrefix, deviceName+"device created")
 	return nil
 }
 
@@ -118,14 +118,14 @@ func (service *LinuxTunDeviceManager) deleteDevice(device tunDevice) {
 	// Cleaning here as much as possible, if device deletion failed we at least unassigned IP-addresses.
 	cmd := exec.Command("sudo", "ip", "addr", "flush", "dev", device.Name)
 	if output, err := cmd.CombinedOutput(); err != nil {
-		log.Warn("Failed to flush tun device: ", cmd.Args, " Returned exit error: ", err.Error(), " Cmd output: ", string(output))
+		log.Warn("Failed to flush tun device:", cmd.Args, "Returned exit error:", err, "Cmd output:", string(output))
 	}
 
 	cmd = exec.Command("sudo", "ip", "tuntap", "delete", "dev", device.Name, "mode", "tun")
 	if output, err := cmd.CombinedOutput(); err != nil {
-		log.Warn("Failed to remove tun device: ", cmd.Args, " Returned exit error: ", err.Error(), " Cmd output: ", string(output))
+		log.Warn("Failed to remove tun device:", cmd.Args, "Returned exit error:", err, "Cmd output:", string(output))
 	} else {
-		log.Info(tunLogPrefix, device.Name, " device removed")
+		log.Info(tunLogPrefix, device.Name, "device removed")
 	}
 }
 
@@ -141,19 +141,19 @@ func (service *LinuxTunDeviceManager) getNextFreeTunDevice() (tun tunDevice, err
 				return tunDevice{}, errors.Wrap(err, "failed to check if device is used")
 			}
 			if !used {
-				log.Trace("tunnel exists, but not used, reusing: " + tunFile)
+				log.Debug("Tunnel exists, but not used, reusing:" + tunFile)
 				return tunDevice{tunName}, nil
 			}
-			log.Trace("tunnel exists and is taken: " + tunFile)
+			log.Debug("Tunnel exists and is taken:" + tunFile)
 		} else if os.IsNotExist(err) {
-			log.Trace("tunnel does not exists, creating: " + tunFile)
+			log.Debug("Tunnel does not exists, creating:" + tunFile)
 			err := service.createTunDevice(tunName)
 			if err != nil {
 				return tunDevice{}, errors.Wrap(err, "failed to create a tunnel: "+tunFile)
 			}
 			return tunDevice{tunName}, nil
 		} else if err != nil {
-			log.Error("failed to check if tunnel device exists", err)
+			log.Error("Failed to check if tunnel device exists:", err)
 		}
 	}
 
@@ -176,7 +176,7 @@ func (service *LinuxTunDeviceManager) createDeviceNode() error {
 
 	cmd := exec.Command("sudo", service.scriptSetup)
 	if output, err := cmd.CombinedOutput(); err != nil {
-		log.Warn("Failed to execute tun script: ", cmd.Args, " Returned exit error: ", err.Error(), " Cmd output: ", string(output))
+		log.Warn("Failed to execute tun script:", cmd.Args, "Returned exit error:", err, "Cmd output:", string(output))
 		return err
 	}
 


### PR DESCRIPTION
Removed seelog. By default, everything will be logged to stdout.

Provided `Logger` interface to adapt to any other logger implementation (e.g. zerolog).

Ref: https://github.com/mysteriumnetwork/node/issues/1290