### PR TITLE
Prevent clients from accessing LAN subnets

### DIFF
--- a/openvpn/middlewares/server/event.go
+++ b/openvpn/middlewares/server/event.go
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/go-openvpn" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package server
+
+// ClientEventType is a OpenVPN management client event.
+type ClientEventType string
+
+const (
+	// Connect represent a CONNECT OpenVPN event type.
+	Connect = ClientEventType("CONNECT")
+	// Reauth represent a REAUTH OpenVPN event type.
+	Reauth = ClientEventType("REAUTH")
+	// Established represent a ESTABLISHED OpenVPN event type.
+	Established = ClientEventType("ESTABLISHED")
+	// Disconnect represent a DISCONNECT OpenVPN event type.
+	Disconnect = ClientEventType("DISCONNECT")
+	// Address represent a ADDRESS OpenVPN event type.
+	Address = ClientEventType("ADDRESS")
+
+	//Env is a pseudo event type ENV - that means some of above defined events are multiline and ENV messages are part of it
+	Env = ClientEventType("ENV")
+	//Undefined is a constant which means that id of type int is undefined
+	Undefined = -1
+)
+
+// ClientEvent represent a OpenVPN management client event.
+type ClientEvent struct {
+	EventType ClientEventType
+	ClientID  int
+	ClientKey int
+	Env       map[string]string
+}
+
+// UndefinedEvent is an empty OpenVPN management client event.
+var UndefinedEvent = ClientEvent{
+	ClientID:  Undefined,
+	ClientKey: Undefined,
+	Env:       make(map[string]string),
+}

--- a/openvpn/middlewares/server/filter/middleware.go
+++ b/openvpn/middlewares/server/filter/middleware.go
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/go-openvpn" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package filter
+
+import (
+	"bytes"
+	"html/template"
+	"strings"
+
+	"github.com/mysteriumnetwork/go-openvpn/openvpn/log"
+	"github.com/mysteriumnetwork/go-openvpn/openvpn/management"
+	"github.com/mysteriumnetwork/go-openvpn/openvpn/middlewares/server"
+)
+
+const filterLANTemplate = `client-pf {{.ClientID}}
+[CLIENTS DROP]
+[SUBNETS ACCEPT]
+{{- range $subnet := .Allow}}
++{{$subnet}}
+{{- end}}
+{{- range $subnet := .Block}}
+-{{$subnet}}
+{{- end}}
+[END]
+END
+`
+
+var filterLAN = template.Must(template.New("filter_lan").Parse(filterLANTemplate))
+
+type middleware struct {
+	commandWriter management.CommandWriter
+	currentEvent  server.ClientEvent
+	allow         []string
+	block         []string
+}
+
+// NewMiddleware creates server user_auth challenge authentication middleware
+func NewMiddleware(allow, block []string) *middleware {
+	return &middleware{
+		commandWriter: nil,
+		allow:         allow,
+		block:         block,
+	}
+}
+
+func (m *middleware) Start(commandWriter management.CommandWriter) error {
+	m.commandWriter = commandWriter
+	return nil
+}
+
+func (m *middleware) Stop(commandWriter management.CommandWriter) error {
+	return nil
+}
+
+func (m *middleware) ConsumeLine(line string) (bool, error) {
+	if !strings.HasPrefix(line, ">CLIENT:") {
+		return false, nil
+	}
+
+	clientLine := strings.TrimPrefix(line, ">CLIENT:")
+
+	eventType, eventData, err := server.ParseClientEvent(clientLine)
+	if err != nil {
+		return true, err
+	}
+
+	switch eventType {
+	case server.Connect, server.Reauth:
+		clientID, _, err := server.ParseIDAndKey(eventData)
+		if err != nil {
+			return true, err
+		}
+
+		m.currentEvent.EventType = eventType
+		m.currentEvent.ClientID = clientID
+	case server.Env:
+		if strings.ToLower(eventData) == "end" {
+			m.handleClientEvent(m.currentEvent)
+		}
+	}
+
+	return true, nil
+}
+
+func (m *middleware) handleClientEvent(event server.ClientEvent) {
+	switch event.EventType {
+	case server.Connect, server.Reauth:
+		if err := filterSubnets(m.commandWriter, event.ClientID, m.allow, m.block); err != nil {
+			log.Error("Unable to authenticate client:", err)
+		}
+	}
+}
+
+func filterSubnets(commandWriter management.CommandWriter, clientID int, allow, block []string) error {
+	data := struct {
+		ClientID int
+		Allow    []string
+		Block    []string
+	}{
+		ClientID: clientID,
+		Allow:    allow,
+		Block:    block,
+	}
+
+	var tpl bytes.Buffer
+	if err := filterLAN.Execute(&tpl, data); err != nil {
+		return err
+	}
+
+	_, err := commandWriter.SingleLineCommand(tpl.String())
+
+	return err
+}

--- a/openvpn/middlewares/server/filter/middleware_test.go
+++ b/openvpn/middlewares/server/filter/middleware_test.go
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2019 The "MysteriumNetwork/go-openvpn" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package filter
+
+import (
+	"testing"
+
+	"github.com/mysteriumnetwork/go-openvpn/openvpn/management"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	emptyFilter = `client-pf 0
+[CLIENTS DROP]
+[SUBNETS ACCEPT]
+[END]
+END
+`
+
+	allowFilter = `client-pf 0
+[CLIENTS DROP]
+[SUBNETS ACCEPT]
++1.1.1.1/32
++2.2.2.0/24
+[END]
+END
+`
+
+	blockFilter = `client-pf 0
+[CLIENTS DROP]
+[SUBNETS ACCEPT]
+-1.1.1.1/32
+-2.2.2.0/24
+[END]
+END
+`
+
+	bothFilter = `client-pf 0
+[CLIENTS DROP]
+[SUBNETS ACCEPT]
++1.1.1.1/32
++2.2.2.0/24
+-3.3.3.3/32
+-4.4.4.0/24
+[END]
+END
+`
+)
+
+func Test_EmptyPacketFilterForEmptySubnets(t *testing.T) {
+	middleware := NewMiddleware(nil, nil)
+	mockConnection := &management.MockConnection{}
+	middleware.Start(mockConnection)
+
+	consumed, err := middleware.ConsumeLine(">CLIENT:CONNECT,0,0")
+	assert.NoError(t, err)
+	assert.True(t, consumed)
+	consumed, err = middleware.ConsumeLine(">CLIENT:ENV,END")
+	assert.NoError(t, err)
+	assert.True(t, consumed)
+
+	assert.Equal(t, emptyFilter, mockConnection.WrittenLines[0])
+}
+
+func Test_AllowPacketFilterForAllowSubnets(t *testing.T) {
+	middleware := NewMiddleware([]string{"1.1.1.1/32", "2.2.2.0/24"}, nil)
+	mockConnection := &management.MockConnection{}
+	middleware.Start(mockConnection)
+
+	consumed, err := middleware.ConsumeLine(">CLIENT:CONNECT,0,0")
+	assert.NoError(t, err)
+	assert.True(t, consumed)
+	consumed, err = middleware.ConsumeLine(">CLIENT:ENV,END")
+	assert.NoError(t, err)
+	assert.True(t, consumed)
+
+	assert.Equal(t, allowFilter, mockConnection.WrittenLines[0])
+}
+
+func Test_BlockPacketFilterForBlockSubnets(t *testing.T) {
+	middleware := NewMiddleware(nil, []string{"1.1.1.1/32", "2.2.2.0/24"})
+	mockConnection := &management.MockConnection{}
+	middleware.Start(mockConnection)
+
+	consumed, err := middleware.ConsumeLine(">CLIENT:CONNECT,0,0")
+	assert.NoError(t, err)
+	assert.True(t, consumed)
+	consumed, err = middleware.ConsumeLine(">CLIENT:ENV,END")
+	assert.NoError(t, err)
+	assert.True(t, consumed)
+
+	assert.Equal(t, blockFilter, mockConnection.WrittenLines[0])
+}
+
+func Test_BothPacketFilterForBothSubnets(t *testing.T) {
+	middleware := NewMiddleware([]string{"1.1.1.1/32", "2.2.2.0/24"}, []string{"3.3.3.3/32", "4.4.4.0/24"})
+	mockConnection := &management.MockConnection{}
+	middleware.Start(mockConnection)
+
+	consumed, err := middleware.ConsumeLine(">CLIENT:CONNECT,0,0")
+	assert.NoError(t, err)
+	assert.True(t, consumed)
+	consumed, err = middleware.ConsumeLine(">CLIENT:ENV,END")
+	assert.NoError(t, err)
+	assert.True(t, consumed)
+
+	assert.Equal(t, bothFilter, mockConnection.WrittenLines[0])
+}

--- a/openvpn/middlewares/server/parsing.go
+++ b/openvpn/middlewares/server/parsing.go
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package auth
+package server
 
 import (
 	"errors"
@@ -30,49 +30,60 @@ var (
 	ruleClientEvent = regexp.MustCompile(`^(\w+),(.*)$`)
 )
 
-func parseClientEvent(line string) (clientEventType, string, error) {
+// ParseClientEvent parses OpenVPN management client event.
+func ParseClientEvent(line string) (ClientEventType, string, error) {
 	match := ruleClientEvent.FindStringSubmatch(line)
 	if len(match) < 3 {
 		return "", "", errors.New("unable to parse event: " + line)
 	}
-	event := clientEventType(match[1])
+
+	event := ClientEventType(match[1])
 	return event, match[2], nil
 }
 
-func parseEnvVar(data string) (string, string, error) {
+// ParseEnvVar parses OpenVPN management client environment variable.
+func ParseEnvVar(data string) (string, string, error) {
 	slice := strings.SplitN(data, "=", 2)
 	if len(slice) == 2 {
 		return slice[0], slice[1], nil
 	} else if len(slice) == 1 {
 		return slice[0], "", nil
 	}
+
 	return "", "", errors.New("invalid env var: " + data)
 }
 
-func parseIDAndKey(data string) (int, int, error) {
+// ParseIDAndKey parses CID and KID from OpenVPN management client.
+func ParseIDAndKey(data string) (int, int, error) {
 	match := ruleIDAndKey.FindStringSubmatch(data)
 	if len(match) < 3 {
-		return undefined, undefined, errors.New("unable to parse identifiers: " + data)
+		return Undefined, Undefined, errors.New("unable to parse identifiers: " + data)
 	}
+
 	ID, err := strconv.Atoi(match[1])
 	if err != nil {
-		return undefined, undefined, err
+		return Undefined, Undefined, err
 	}
+
 	key, err := strconv.Atoi(match[2])
 	if err != nil {
-		return undefined, undefined, err
+		return Undefined, Undefined, err
 	}
+
 	return ID, key, nil
 }
 
-func parseID(data string) (int, error) {
+// ParseID parses CID from OpenVPN management client.
+func ParseID(data string) (int, error) {
 	match := ruleID.FindStringSubmatch(data)
 	if len(match) < 2 {
-		return undefined, errors.New("unable to parse identifier: " + data)
+		return Undefined, errors.New("unable to parse identifier: " + data)
 	}
+
 	ID, err := strconv.Atoi(match[1])
 	if err != nil {
-		return undefined, err
+		return Undefined, err
 	}
+
 	return ID, nil
 }

--- a/openvpn/middlewares/server/parsing_test.go
+++ b/openvpn/middlewares/server/parsing_test.go
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package auth
+package server
 
 import (
 	"errors"
@@ -27,21 +27,21 @@ import (
 func TestClientEventIsParsed(t *testing.T) {
 	var testData = []struct {
 		testLine  string
-		event     clientEventType
+		event     ClientEventType
 		eventData string
 		err       error
 	}{
-		{"CONNECT,1,1", connect, "1,1", nil},
-		{"REAUTH,2,2", reauth, "2,2", nil},
-		{"ENV,abc=123", env, "abc=123", nil},
-		{"ESTABLISHED,1", established, "1", nil},
-		{"DISCONNECT,1", disconnect, "1", nil},
-		{"ADDRESS,123,ip1,ipsubnet", address, "123,ip1,ipsubnet", nil},
+		{"CONNECT,1,1", Connect, "1,1", nil},
+		{"REAUTH,2,2", Reauth, "2,2", nil},
+		{"ENV,abc=123", Env, "abc=123", nil},
+		{"ESTABLISHED,1", Established, "1", nil},
+		{"DISCONNECT,1", Disconnect, "1", nil},
+		{"ADDRESS,123,ip1,ipsubnet", Address, "123,ip1,ipsubnet", nil},
 		{"UNPARSEABLE", "", "", errors.New("unable to parse event: UNPARSEABLE")},
 	}
 
 	for _, test := range testData {
-		event, eventData, err := parseClientEvent(test.testLine)
+		event, eventData, err := ParseClientEvent(test.testLine)
 		assert.Equal(t, test.event, event, test.testLine)
 		assert.Equal(t, test.eventData, eventData, test.testLine)
 		assert.Equal(t, test.err, err, test.testLine)
@@ -62,7 +62,7 @@ func TestEnvVarIsParsed(t *testing.T) {
 	}
 
 	for _, test := range testData {
-		key, val, err := parseEnvVar(test.testLine)
+		key, val, err := ParseEnvVar(test.testLine)
 		assert.Equal(t, test.key, key, test.testLine)
 		assert.Equal(t, test.val, val, test.testLine)
 		assert.Equal(t, test.err, err, test.testLine)
@@ -77,13 +77,13 @@ func TestIDAndKeyIsParsed(t *testing.T) {
 		err      error
 	}{
 		{"123,456", 123, 456, nil},
-		{"abc,def", undefined, undefined, errors.New("unable to parse identifiers: abc,def")},
-		{"garbage", undefined, undefined, errors.New("unable to parse identifiers: garbage")},
-		{"123,abc", undefined, undefined, errors.New("unable to parse identifiers: 123,abc")},
+		{"abc,def", Undefined, Undefined, errors.New("unable to parse identifiers: abc,def")},
+		{"garbage", Undefined, Undefined, errors.New("unable to parse identifiers: garbage")},
+		{"123,abc", Undefined, Undefined, errors.New("unable to parse identifiers: 123,abc")},
 	}
 
 	for _, test := range testData {
-		ID, key, err := parseIDAndKey(test.testLine)
+		ID, key, err := ParseIDAndKey(test.testLine)
 		assert.Equal(t, test.ID, ID, test.testLine)
 		assert.Equal(t, test.key, key, test.testLine)
 		assert.Equal(t, test.err, err, test.testLine)
@@ -97,11 +97,11 @@ func TestIDIsParsed(t *testing.T) {
 		err      error
 	}{
 		{"123", 123, nil},
-		{"garbage", undefined, errors.New("unable to parse identifier: garbage")},
+		{"garbage", Undefined, errors.New("unable to parse identifier: garbage")},
 	}
 
 	for _, test := range testData {
-		ID, err := parseID(test.testLine)
+		ID, err := ParseID(test.testLine)
 		assert.Equal(t, test.ID, ID, test.testLine)
 		assert.Equal(t, test.err, err, test.testLine)
 	}


### PR DESCRIPTION
Another part of this feature is here: https://github.com/mysteriumnetwork/node/pull/1420

This PR enables internal OpenVPN packet filtering, which is platform-independent. 