### PR TITLE
Expose server's middleware for incoming clients control

### DIFF
--- a/openvpn/middlewares/server/credentials/middleware.go
+++ b/openvpn/middlewares/server/credentials/middleware.go
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2020 The "MysteriumNetwork/go-openvpn" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package credentials
+
+import (
+	"github.com/mysteriumnetwork/go-openvpn/openvpn/log"
+	"github.com/mysteriumnetwork/go-openvpn/openvpn/middlewares/server"
+	"github.com/mysteriumnetwork/go-openvpn/openvpn/middlewares/server/auth"
+)
+
+// Middleware is able to process authorize incoming clients by given credentials validator callback.
+type Middleware struct {
+	*auth.Middleware
+
+	validator Validator
+}
+
+// Validator callback checks given auth primitives.
+type Validator func(clientID int, username, password string) (bool, error)
+
+// NewMiddleware creates server user_auth challenge authentication Middleware
+func NewMiddleware(validator Validator) *Middleware {
+	m := &Middleware{
+		validator: validator,
+	}
+	m.Middleware = auth.NewMiddleware(m.handleClientEvent)
+	return m
+}
+
+func (m *Middleware) handleClientEvent(event server.ClientEvent) {
+	switch event.EventType {
+	case server.Connect, server.Reauth:
+		username := event.Env["username"]
+		password := event.Env["password"]
+		err := m.authenticateClient(event.ClientID, event.ClientKey, username, password)
+		if err != nil {
+			log.Error("Unable to authenticate client:", err)
+		}
+	case server.Established:
+		log.Info("Client with ID:", event.ClientID, "connection established successfully")
+	case server.Disconnect:
+		log.Info("Client with ID:", event.ClientID, "disconnected")
+	}
+}
+
+func (m *Middleware) authenticateClient(clientID, clientKey int, username, password string) error {
+	log.Info("Authenticating user:", username, "clientID:", clientID, "clientKey:", clientKey)
+	if username == "" || password == "" {
+		return m.ClientDenyWithMessage(clientID, clientKey, "missing username or password")
+	}
+
+	authenticated, err := m.validator(clientID, username, password)
+	if err != nil {
+		log.Error("Authentication error:", err)
+		return m.ClientDenyWithMessage(clientID, clientKey, "internal error")
+	}
+
+	if !authenticated {
+		return m.ClientDenyWithMessage(clientID, clientKey, "wrong username or password")
+	}
+
+	return m.ClientAccept(clientID, clientKey)
+}

--- a/openvpn/middlewares/server/credentials/middleware.go
+++ b/openvpn/middlewares/server/credentials/middleware.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mysteriumnetwork/go-openvpn/openvpn/middlewares/server/auth"
 )
 
-// Middleware is able to process authorize incoming clients by given credentials validator callback.
+// Middleware is able to authorize incoming clients by given credentials validator callback.
 type Middleware struct {
 	*auth.Middleware
 
@@ -35,10 +35,9 @@ type Validator func(clientID int, username, password string) (bool, error)
 
 // NewMiddleware creates server user_auth challenge authentication Middleware
 func NewMiddleware(validator Validator) *Middleware {
-	m := &Middleware{
-		validator: validator,
-	}
+	m := new(Middleware)
 	m.Middleware = auth.NewMiddleware(m.handleClientEvent)
+	m.validator = validator
 	return m
 }
 

--- a/openvpn/middlewares/server/credentials/middleware_test.go
+++ b/openvpn/middlewares/server/credentials/middleware_test.go
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2020 The "MysteriumNetwork/go-openvpn" Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package credentials
+
+import (
+	"testing"
+
+	"github.com/mysteriumnetwork/go-openvpn/openvpn/management"
+	"github.com/mysteriumnetwork/go-openvpn/openvpn/middlewares/server"
+	"github.com/mysteriumnetwork/go-openvpn/openvpn/middlewares/server/auth"
+	"github.com/stretchr/testify/assert"
+)
+
+type fakeValidator struct {
+	called bool
+}
+
+func (f *fakeValidator) authenticateClient(clientID int, username, password string) (bool, error) {
+	f.called = true
+	return username == "username1" && password == "12341234", nil
+}
+
+func mockAuthMiddleware(connection *management.MockConnection) *auth.Middleware {
+	m := auth.NewMiddleware()
+	m.Start(connection)
+	return m
+}
+
+func Test_Factory(t *testing.T) {
+	fas := fakeValidator{}
+	middleware := NewMiddleware(fas.authenticateClient)
+	assert.NotNil(t, middleware)
+}
+
+func Test_ConsumeLineAuthTrueChecker(t *testing.T) {
+	fas := fakeValidator{}
+
+	mockConnection := &management.MockConnection{}
+	middleware := NewMiddleware(fas.authenticateClient)
+	middleware.Start(mockConnection)
+
+	middleware.handleClientEvent(server.ClientEvent{
+		EventType: server.Connect,
+		ClientID:  3,
+		ClientKey: 4,
+		Env: map[string]string{
+			"username": "username1",
+			"password": "12341234",
+		},
+	})
+	assert.Equal(t, "client-auth-nt 3 4", mockConnection.LastLine)
+}
+
+func Test_ConsumeLineAuthFalseChecker(t *testing.T) {
+	fas := fakeValidator{}
+
+	mockConnection := &management.MockConnection{}
+	middleware := NewMiddleware(fas.authenticateClient)
+	middleware.Start(mockConnection)
+
+	middleware.handleClientEvent(server.ClientEvent{
+		EventType: server.Connect,
+		ClientID:  3,
+		ClientKey: 4,
+	})
+	assert.Equal(t, "client-deny 3 4 missing username or password", mockConnection.LastLine)
+
+	middleware.handleClientEvent(server.ClientEvent{
+		EventType: server.Connect,
+		ClientID:  3,
+		ClientKey: 4,
+		Env: map[string]string{
+			"username": "username1",
+			"password": "wrong",
+		},
+	})
+	assert.Equal(t, "client-deny 3 4 wrong username or password", mockConnection.LastLine)
+}

--- a/openvpn/middlewares/server/credentials/middleware_test.go
+++ b/openvpn/middlewares/server/credentials/middleware_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/mysteriumnetwork/go-openvpn/openvpn/management"
 	"github.com/mysteriumnetwork/go-openvpn/openvpn/middlewares/server"
-	"github.com/mysteriumnetwork/go-openvpn/openvpn/middlewares/server/auth"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -33,12 +32,6 @@ type fakeValidator struct {
 func (f *fakeValidator) authenticateClient(clientID int, username, password string) (bool, error) {
 	f.called = true
 	return username == "username1" && password == "12341234", nil
-}
-
-func mockAuthMiddleware(connection *management.MockConnection) *auth.Middleware {
-	m := auth.NewMiddleware()
-	m.Start(connection)
-	return m
 }
 
 func Test_Factory(t *testing.T) {

--- a/openvpn/middlewares/server/event.go
+++ b/openvpn/middlewares/server/event.go
@@ -47,8 +47,11 @@ type ClientEvent struct {
 }
 
 // UndefinedEvent is an empty OpenVPN management client event.
-var UndefinedEvent = ClientEvent{
-	ClientID:  Undefined,
-	ClientKey: Undefined,
-	Env:       make(map[string]string),
+// Note: can't be a var, because `ClientEvent.Env` variable is being overwritten as it's a reference to same memory.
+func UndefinedEvent() ClientEvent {
+	return ClientEvent{
+		ClientID:  Undefined,
+		ClientKey: Undefined,
+		Env:       make(map[string]string),
+	}
 }

--- a/openvpn/middlewares/server/filter/middleware.go
+++ b/openvpn/middlewares/server/filter/middleware.go
@@ -20,11 +20,11 @@ package filter
 import (
 	"bytes"
 	"html/template"
-	"strings"
 
 	"github.com/mysteriumnetwork/go-openvpn/openvpn/log"
 	"github.com/mysteriumnetwork/go-openvpn/openvpn/management"
 	"github.com/mysteriumnetwork/go-openvpn/openvpn/middlewares/server"
+	"github.com/mysteriumnetwork/go-openvpn/openvpn/middlewares/server/auth"
 )
 
 const filterLANTemplate = `client-pf {{.ClientID}}
@@ -42,59 +42,34 @@ END
 
 var filterLAN = template.Must(template.New("filter_lan").Parse(filterLANTemplate))
 
+// Exposes API to control client's packet filtering.
+//
+// The OpenVPN server should have been started with the
+// --management-client-pf directive so that it will require that
+// VPN tunnel packets sent or received by client instances must
+// conform to that client's packet filter configuration.
 type middleware struct {
+	*auth.Middleware
+
 	commandWriter management.CommandWriter
-	currentEvent  server.ClientEvent
 	allow         []string
 	block         []string
 }
 
-// NewMiddleware creates server user_auth challenge authentication middleware
+// NewMiddleware creates new instance of middleware
 func NewMiddleware(allow, block []string) *middleware {
-	return &middleware{
+	m := &middleware{
 		commandWriter: nil,
 		allow:         allow,
 		block:         block,
 	}
+	m.Middleware = auth.NewMiddleware(m.handleClientEvent)
+	return m
 }
 
 func (m *middleware) Start(commandWriter management.CommandWriter) error {
 	m.commandWriter = commandWriter
-	return nil
-}
-
-func (m *middleware) Stop(commandWriter management.CommandWriter) error {
-	return nil
-}
-
-func (m *middleware) ConsumeLine(line string) (bool, error) {
-	if !strings.HasPrefix(line, ">CLIENT:") {
-		return false, nil
-	}
-
-	clientLine := strings.TrimPrefix(line, ">CLIENT:")
-
-	eventType, eventData, err := server.ParseClientEvent(clientLine)
-	if err != nil {
-		return true, err
-	}
-
-	switch eventType {
-	case server.Connect, server.Reauth:
-		clientID, _, err := server.ParseIDAndKey(eventData)
-		if err != nil {
-			return true, err
-		}
-
-		m.currentEvent.EventType = eventType
-		m.currentEvent.ClientID = clientID
-	case server.Env:
-		if strings.ToLower(eventData) == "end" {
-			m.handleClientEvent(m.currentEvent)
-		}
-	}
-
-	return true, nil
+	return m.Middleware.Start(commandWriter)
 }
 
 func (m *middleware) handleClientEvent(event server.ClientEvent) {

--- a/openvpn/middlewares/server/filter/middleware.go
+++ b/openvpn/middlewares/server/filter/middleware.go
@@ -58,12 +58,10 @@ type middleware struct {
 
 // NewMiddleware creates new instance of middleware
 func NewMiddleware(allow, block []string) *middleware {
-	m := &middleware{
-		commandWriter: nil,
-		allow:         allow,
-		block:         block,
-	}
+	m := new(middleware)
 	m.Middleware = auth.NewMiddleware(m.handleClientEvent)
+	m.allow = allow
+	m.block = block
 	return m
 }
 

--- a/openvpn/middlewares/server/filter/middleware_test.go
+++ b/openvpn/middlewares/server/filter/middleware_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/mysteriumnetwork/go-openvpn/openvpn/management"
+	"github.com/mysteriumnetwork/go-openvpn/openvpn/middlewares/server"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -63,17 +64,11 @@ END
 )
 
 func Test_EmptyPacketFilterForEmptySubnets(t *testing.T) {
-	middleware := NewMiddleware(nil, nil)
 	mockConnection := &management.MockConnection{}
+	middleware := NewMiddleware(nil, nil)
 	middleware.Start(mockConnection)
 
-	consumed, err := middleware.ConsumeLine(">CLIENT:CONNECT,0,0")
-	assert.NoError(t, err)
-	assert.True(t, consumed)
-	consumed, err = middleware.ConsumeLine(">CLIENT:ENV,END")
-	assert.NoError(t, err)
-	assert.True(t, consumed)
-
+	middleware.handleClientEvent(server.ClientEvent{EventType: server.Connect, ClientID: 0})
 	assert.Equal(t, emptyFilter, mockConnection.WrittenLines[0])
 }
 
@@ -82,13 +77,7 @@ func Test_AllowPacketFilterForAllowSubnets(t *testing.T) {
 	mockConnection := &management.MockConnection{}
 	middleware.Start(mockConnection)
 
-	consumed, err := middleware.ConsumeLine(">CLIENT:CONNECT,0,0")
-	assert.NoError(t, err)
-	assert.True(t, consumed)
-	consumed, err = middleware.ConsumeLine(">CLIENT:ENV,END")
-	assert.NoError(t, err)
-	assert.True(t, consumed)
-
+	middleware.handleClientEvent(server.ClientEvent{EventType: server.Connect, ClientID: 0})
 	assert.Equal(t, allowFilter, mockConnection.WrittenLines[0])
 }
 
@@ -97,13 +86,7 @@ func Test_BlockPacketFilterForBlockSubnets(t *testing.T) {
 	mockConnection := &management.MockConnection{}
 	middleware.Start(mockConnection)
 
-	consumed, err := middleware.ConsumeLine(">CLIENT:CONNECT,0,0")
-	assert.NoError(t, err)
-	assert.True(t, consumed)
-	consumed, err = middleware.ConsumeLine(">CLIENT:ENV,END")
-	assert.NoError(t, err)
-	assert.True(t, consumed)
-
+	middleware.handleClientEvent(server.ClientEvent{EventType: server.Connect, ClientID: 0})
 	assert.Equal(t, blockFilter, mockConnection.WrittenLines[0])
 }
 
@@ -112,12 +95,6 @@ func Test_BothPacketFilterForBothSubnets(t *testing.T) {
 	mockConnection := &management.MockConnection{}
 	middleware.Start(mockConnection)
 
-	consumed, err := middleware.ConsumeLine(">CLIENT:CONNECT,0,0")
-	assert.NoError(t, err)
-	assert.True(t, consumed)
-	consumed, err = middleware.ConsumeLine(">CLIENT:ENV,END")
-	assert.NoError(t, err)
-	assert.True(t, consumed)
-
+	middleware.handleClientEvent(server.ClientEvent{EventType: server.Connect, ClientID: 0})
 	assert.Equal(t, bothFilter, mockConnection.WrittenLines[0])
 }


### PR DESCRIPTION
Updates: https://github.com/mysteriumnetwork/node/issues/1838

- Server's callbacks to subscribe and incoming client data: Openvpn variables, states
- Expose client authorisation control